### PR TITLE
this option tells iconoclash to write each svg out to a file instead …

### DIFF
--- a/src/iconoclash.js
+++ b/src/iconoclash.js
@@ -138,7 +138,7 @@
 				config.autoExpose.forEach(function(i){
 					let attr = i;
 					if(!elem.attribs[i]){
-						elem.attribs[i] = "currentColor";
+						elem.attribs[i] = "initial";
 					}
 				});
 			});


### PR DESCRIPTION
…of one big sprite. the inside of each new file has all the same mechanics of the big sprite, but this means you can load only the icons a page uses